### PR TITLE
Add option to build the bzip2 library, only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ set(BZ2_LIBRARY bz2)
 set(BZ2_NAMESPACE BZip2)
 set(BZ2_CONFIG ${BZ2_NAMESPACE}Config)
 
+option(BZ2_BUILD_EXE OFF)
+
 add_library(${BZ2_LIBRARY}  ${SOURCE_SUBFOLDER}/blocksort.c
                             ${SOURCE_SUBFOLDER}/bzlib.c
                             ${SOURCE_SUBFOLDER}/compress.c
@@ -27,9 +29,11 @@ add_library(${BZ2_LIBRARY}  ${SOURCE_SUBFOLDER}/blocksort.c
                             ${SOURCE_SUBFOLDER}/bzlib_private.h)
 target_include_directories(${BZ2_LIBRARY} PRIVATE ${SOURCE_SUBFOLDER})
 
-add_executable(${CMAKE_PROJECT_NAME} ${SOURCE_SUBFOLDER}/bzip2.c)
-target_link_libraries(${CMAKE_PROJECT_NAME} ${BZ2_LIBRARY})
-target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${SOURCE_SUBFOLDER})
+if(BZ2_BUILD_EXE)
+    add_executable(${CMAKE_PROJECT_NAME} ${SOURCE_SUBFOLDER}/bzip2.c)
+    target_link_libraries(${CMAKE_PROJECT_NAME} ${BZ2_LIBRARY})
+    target_include_directories(${CMAKE_PROJECT_NAME} PRIVATE ${SOURCE_SUBFOLDER})
+endif()
 
 set_target_properties(${BZ2_LIBRARY} PROPERTIES VERSION ${BZ2_VERSION_STRING} SOVERSION ${BZ2_VERSION_MAJOR})
 
@@ -37,11 +41,19 @@ export(TARGETS ${BZ2_LIBRARY}
        NAMESPACE ${BZ2_NAMESPACE}::
        FILE "${CMAKE_CURRENT_BINARY_DIR}/${BZ2_CONFIG}.cmake")
 
-install(TARGETS ${CMAKE_PROJECT_NAME} ${BZ2_LIBRARY}
+install(TARGETS ${BZ2_LIBRARY}
         EXPORT ${BZ2_CONFIG}
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib
         ARCHIVE DESTINATION lib)
+
+if(BZ2_BUILD_EXE)
+    install(TARGETS ${CMAKE_PROJECT_NAME}
+            EXPORT ${BZ2_CONFIG}
+            RUNTIME DESTINATION bin
+            LIBRARY DESTINATION lib
+            ARCHIVE DESTINATION lib)
+endif()
 
 install(FILES ${SOURCE_SUBFOLDER}/bzlib.h DESTINATION include)
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -15,8 +15,8 @@ class Bzip2Conan(ConanFile):
     description = "bzip2 is a free and open-source file compression program that uses the Burrows–Wheeler algorithm."
     topics = ("conan", "bzip2", "data-compressor", "file-compression")
     settings = "os", "compiler", "arch", "build_type"
-    options = {"shared": [True, False], "fPIC": [True, False]}
-    default_options = "shared=False", "fPIC=True"
+    options = {"shared": [True, False], "fPIC": [True, False], "build_executable": [True, False]}
+    default_options = "shared=False", "fPIC=True", "build_executable=True"
     exports = "LICENSE"
     exports_sources = "CMakeLists.txt"
     generators = "cmake"
@@ -42,6 +42,7 @@ class Bzip2Conan(ConanFile):
         cmake = CMake(self)
         cmake.definitions["BZ2_VERSION_STRING"] = self.version
         cmake.definitions["BZ2_VERSION_MAJOR"] = major
+        cmake.definitions["BZ2_BUILD_EXE"] = "ON" if self.options.build_executable else "OFF"
         cmake.configure()
         return cmake
 


### PR DESCRIPTION
When building for embedded systems, compiling bzip2.c will generally fail due to lack of full POSIX support. The library, libbz2, compiles just fine though, so making the executable part optional enables the library to be used on more platforms.

The new option controls whether to build the bzip2 executable or not. It's called "bzip2:build_executable" and is enabled by default (hence preserving current behavior).

This is my first attempt at modifying a Conan recipe, so I didn't put much thought into polishing and instead wanted to make sure this patch is going in the right direction. I'll happily make adjustments if it's fine though!
